### PR TITLE
Explain error caused by missing argument vector

### DIFF
--- a/clj/illegalargumentexception-parameter-declaration-should-be-a-vector.md
+++ b/clj/illegalargumentexception-parameter-declaration-should-be-a-vector.md
@@ -1,4 +1,4 @@
-## IllegalArgumentException Parameter declaration "+" should be a vector 
+## IllegalArgumentException Parameter declaration should be a vector
 
 ### Description
 
@@ -14,7 +14,7 @@ small. Here is an example:
 (defn my-static-adder
   "This is my-static-adder function which will simply add
 two built-in numbers. Nothing spectacular, just to demonstrate
-how easy is to miss argument vector."  
+how easy is to miss argument vector."
   (+ 1 2))
 ```
 
@@ -32,7 +32,7 @@ Add argument vector.
 (defn my-static-adder
   "This is my-static-adder function which will simply add
 two built-in numbers. Nothing spectacular, just to demonstrate
-how easy is to miss argument vector."  
+how easy is to miss argument vector."
   []
   (+ 1 2))
 ```

--- a/clj/illegalargumentexception-parameter-declaration-should-be-a-vector.md
+++ b/clj/illegalargumentexception-parameter-declaration-should-be-a-vector.md
@@ -1,0 +1,38 @@
+## IllegalArgumentException Parameter declaration "+" should be a vector 
+
+### Description
+
+Function declaration is missing arguments vector.
+
+### Cause
+
+When you declare a new function with documentation strings, it is easy
+to forget argument vector, especially if function documentation isn't
+small. Here is an example:
+
+```clojure
+(defn my-static-adder
+  "This is my-static-adder function which will simply add
+two built-in numbers. Nothing spectacular, just to demonstrate
+how easy is to miss argument vector."  
+  (+ 1 2))
+```
+
+After you evaluate it, you can get this:
+
+```log
+IllegalArgumentException Parameter declaration "+" should be a vector  clojure.core/assert-valid-fdecl (core.clj:7196)
+```
+
+### Solution
+
+Add argument vector.
+
+```clojure
+(defn my-static-adder
+  "This is my-static-adder function which will simply add
+two built-in numbers. Nothing spectacular, just to demonstrate
+how easy is to miss argument vector."  
+  []
+  (+ 1 2))
+```


### PR DESCRIPTION
It is easy to miss argument vector and that can cause cryptic message. This explanation provides short sample on how to figure out what is going on.